### PR TITLE
Multiple _cleanCache fixes

### DIFF
--- a/lib/flutter_cache_manager.dart
+++ b/lib/flutter_cache_manager.dart
@@ -159,18 +159,24 @@ class CacheManager {
     //Remove oldest objects when cache contains to many items
     if (_cacheData.length > maxNrOfCacheObjects) {
       var allValues = _cacheData.values.toList();
-      allValues.sort((c1, c2) => c2.touched.compareTo(c1.touched));  // sort OLDEST first
+      allValues.sort((c1, c2) => c1.touched.compareTo(c2.touched));  // sort OLDEST first
       var oldestValues = allValues.take( _cacheData.length - maxNrOfCacheObjects);      // get them
       oldestValues.forEach( (item) async {await _removeFile(item);} );  //remove them
     }
   }
 
   _removeFile(CacheObject cacheObject) async {
+    //Ensure the file has been downloaded
+    if (cacheObject.relativePath == null) {
+      return;
+    }
+
+    _cacheData.remove(cacheObject.url);
+
     var file = new File(await cacheObject.getFilePath());
     if (await file.exists()) {
       file.delete();
     }
-    _cacheData.remove(cacheObject.url);
   }
 
   ///Get the file from the cache or online. Depending on availability and age


### PR DESCRIPTION
@renefloor my use case for the lib is loading a list of small images. When flinging through 100s of images I noticed a problem where `_removeFile` would try to remove a file with a `null` value for `relativePath`. 

Through testing I observed that we were trying to delete images that hadn't been downloaded yet due to an incorrect comparison when sorting the `CacheObject` list in `_shrinkLargeCache`.

After fixing this I observed a second Exception where we were trying to remove the same `CacheObject` multiple times when flinging:

```
E/flutter (16626): FileSystemException: Cannot delete file, path = '...' (OS Error: No such file or directory, errno = 2)
```
By removing the cache entry from the map prior to deleting from disk this is avoided.