### PR TITLE
GetFile only if available in cache.

### DIFF
--- a/lib/flutter_cache_manager.dart
+++ b/lib/flutter_cache_manager.dart
@@ -249,7 +249,7 @@ class CacheManager {
           "$log\nUsing file from cache.\nCache valid till ${_cacheData[url].validTill?.toIso8601String() ?? "only once.. :("}";
     });
 
-    //If non of the above is true, than we don't have to download anything.
+    //If none of the above is true, then we don't have to download anything.
     _save();
     if (showDebugLogs) print(log);
 

--- a/lib/flutter_cache_manager.dart
+++ b/lib/flutter_cache_manager.dart
@@ -184,7 +184,7 @@ class CacheManager {
   }
 
   ///Get the file from the cache or online. Depending on availability and age
-  Future<File> getFile(String url, {Map<String, String> headers}) async {
+  Future<File> getFile(String url, {Map<String, String> headers, bool onlyFromCache}) async {
     String log = "[Flutter Cache Manager] Loading $url";
 
     if (!_cacheData.containsKey(url)) {
@@ -199,6 +199,9 @@ class CacheManager {
     await synchronized(cacheObject.lock, () async {
       // Set touched date to show that this object is being used recently
       cacheObject.touch();
+
+      if (onlyFromCache ?? false)
+        return;
 
       if (headers == null) {
         headers = new Map();


### PR DESCRIPTION
Adding the possibility to skip the actual network download.
Functionality is similar to #14, but I find this approach better in code integration.

Im also issuing a PR in flutter_cached_network_image that uses this feature.
