### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,5 +13,5 @@ dependencies:
   shared_preferences: "^0.4.0"
   path_provider: "^0.4.0"
   synchronized: "^1.3.0"
-  uuid:  "^0.5.3"
+  uuid: "^1.0.3"
   http: "^0.11.3+14"


### PR DESCRIPTION
A number of packages like cache_network_image and uses for the http package  and UUID - if we use the latest versions of these we get a dependancy error.