### PR TITLE
Increase version of http

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
   path_provider: "^0.4.0"
   synchronized: "^1.5.1"
   uuid:  "^1.0.3"
-  http: "^0.11.3+14"
+  http: "^0.12.0"


### PR DESCRIPTION
```
Because every version of flutter_test from sdk depends on http 0.12.0 and flutter_cache_manager >=0.1.0-rc.1 depends on http ^0.11.3+14, flutter_test from sdk is incompatible with flutter_cache_manager >=0.1.0-rc.1.
And because cached_network_image >=0.4.2 depends on flutter_cache_manager ^0.1.2, flutter_test from sdk is incompatible with cached_network_image >=0.4.2.```