### PR TITLE
Keep sqlite connection open forever.

### DIFF
--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -54,8 +54,8 @@ abstract class BaseCacheManager {
   /// The [httpGetter] can be used to customize how files are downloaded. For example
   /// to edit the urls, add headers or use a proxy.
   BaseCacheManager(this._cacheKey,
-      {maxAgeCacheObject = const Duration(days: 30),
-      maxNrOfCacheObjects = 200,
+      {Duration maxAgeCacheObject = const Duration(days: 30),
+      int maxNrOfCacheObjects = 200,
       FileFetcher fileFetcher}) {
     _fileBasePath = getFilePath();
 

--- a/lib/src/cache_object.dart
+++ b/lib/src/cache_object.dart
@@ -144,7 +144,7 @@ class CacheObjectProvider {
   }
 
   Future<List<CacheObject>> getOldObjects(Duration maxAge) async {
-    List<Map> maps = await db.query(
+    List<Map<String, dynamic>> maps = await db.query(
       tableCacheObject,
       where: "$columnTouched < ?",
       columns: null,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   http: ">=0.11.0 < 0.13.0"
   path: "^1.6.2"
   sqflite: "^1.1.0"
-  synchronized: "^2.0.2"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
A small change to keep the SQLite connection open forever, and not open/close the connection for each request.
Imo it is good practice on mobile devices to keep the sqlite open as long as the process lives, and it shouldn't be a problem at all if the app terminates with an open sqlite connection. see e.g. http://touchlabblog.tumblr.com/post/24474750219/single-sqlite-connection /  https://stackoverflow.com/a/7213623/109219

I have also added a scheduled cleanup which gets basically scheduled 10 seconds after a `_getCacheDataFromDatabase` (so, if there are many `get` calls within those 10 seconds, the cleanup still only happens once..)

this pretty much simplifies the code because of the `_nrOfDbConnections` is no longer needed, and 