### PR TITLE
Store plain CacheObject in memory cache to avoid memory leaks

### DIFF
--- a/lib/src/cache_store.dart
+++ b/lib/src/cache_store.dart
@@ -12,7 +12,7 @@ import 'package:synchronized/synchronized.dart';
 ///Released under MIT License.
 
 class CacheStore {
-  Map<String, Future<CacheObject>> _memCache = new Map();
+  Map<String, CacheObject> _memCache = new Map();
 
   int _nrOfDbConnections = 0;
   Future<String> filePath;
@@ -50,7 +50,7 @@ class CacheStore {
   }
 
   putFile(CacheObject cacheObject) async {
-    _memCache[cacheObject.url] = Future<CacheObject>.value(cacheObject);
+    _memCache[cacheObject.url] = cacheObject;
     _updateCacheDataInDatabase(cacheObject);
   }
 
@@ -61,12 +61,13 @@ class CacheStore {
         if (cacheObject != null && !await _fileExists(cacheObject)) {
           cacheObject = new CacheObject(url, id: cacheObject.id);
         }
+        _memCache[url] = cacheObject;
         completer.complete(cacheObject);
       });
-
-      _memCache[url] = completer.future;
+      return completer.future;
+    } else {
+      return Future<CacheObject>.value(_memCache[url]);
     }
-    return _memCache[url];
   }
 
   Future<bool> _fileExists(CacheObject cacheObject) async {


### PR DESCRIPTION
In `flutter_cache_manager 0.3.2` the `CacheStore` holds `Future` objects in its memory cache, this can cause memory leaks in `flutter_cached_network_image`. Check the memory profiles below.

Maybe we should store plain `CacheObject` objects in memory cache instead of `Future` objects to avoid the memory leaks.

## Memory Profile using this patch

![fixed](https://user-images.githubusercontent.com/4081579/56454995-c1878980-638b-11e9-9061-097e8e1dcef5.png)

## Memory Profile using `0.3.2`

![0_3_2_allocation](https://user-images.githubusercontent.com/4081579/56454977-6f466880-638b-11e9-8a1a-21a4b5c4ecfd.png)

![0_3_2_dominator_tree](https://user-images.githubusercontent.com/4081579/56454975-6f466880-638b-11e9-8aac-abeacd17470e.png)
