### PR TITLE
Fix bug in putFile

### DIFF
--- a/lib/src/cache_store.dart
+++ b/lib/src/cache_store.dart
@@ -63,7 +63,7 @@ class CacheStore {
       var completer = new Completer<CacheObject>();
       _getCacheDataFromDatabase(url).then((cacheObject) async {
         if (cacheObject != null && !await _fileExists(cacheObject)) {
-          cacheObject = new CacheObject(url, id: cacheObject.id);
+          cacheObject = new CacheObject(url, relativePath: cacheObject.relativePath, id: cacheObject.id);
         }
         completer.complete(cacheObject);
       });

--- a/lib/src/cache_store.dart
+++ b/lib/src/cache_store.dart
@@ -63,7 +63,9 @@ class CacheStore {
       var completer = new Completer<CacheObject>();
       _getCacheDataFromDatabase(url).then((cacheObject) async {
         if (cacheObject != null && !await _fileExists(cacheObject)) {
-          cacheObject = new CacheObject(url, relativePath: cacheObject.relativePath, id: cacheObject.id);
+          final provider = await _cacheObjectProvider;
+          provider.delete(cacheObject.id);
+          cacheObject = null;
         }
         completer.complete(cacheObject);
       });


### PR DESCRIPTION
I think there is an error when adding a file using the `putFile` method if the file already exists in the database, is not in the memory cache and the file does not exist in the folder. Then in the file `cache_store.dart` in line 65 a new `CacheObject` is created without a relative path. This throws an exception when the file in line 161 of `cache_manager.dart` is written, since the file is now written to a location where there is already a folder. I think the bug can be fixed by adding the relative path from the database to the `CacheObject`.

This PR resolves #80.