### PR TITLE
Add missing await in putFile

### DIFF
--- a/lib/src/cache_store.dart
+++ b/lib/src/cache_store.dart
@@ -54,7 +54,7 @@ class CacheStore {
   }
 
   putFile(CacheObject cacheObject) async {
-    _memCache[cacheObject.url] = Future<CacheObject>.value(cacheObject);
+    _memCache[cacheObject.url] = cacheObject;
     await _updateCacheDataInDatabase(cacheObject);
   }
 

--- a/lib/src/cache_store.dart
+++ b/lib/src/cache_store.dart
@@ -55,7 +55,7 @@ class CacheStore {
 
   putFile(CacheObject cacheObject) async {
     _memCache[cacheObject.url] = Future<CacheObject>.value(cacheObject);
-    _updateCacheDataInDatabase(cacheObject);
+    await _updateCacheDataInDatabase(cacheObject);
   }
 
   Future<CacheObject> retrieveCacheData(String url) {


### PR DESCRIPTION
I think there's a missing await here, I assume it's not intentionally missing.

I noticed this because I have an onboarding step where I download an icon pack as a zip file, and I want to unpack it and pre-cache them (5K images). After the onboarding step the database is locked for some time and I see sqlite spam in the logs: 
Warning database has been locked for 0:00:10.000000. Make sure you always use the transaction object for database operations during a transaction.

With this change made locally the issue goes away.