### PR TITLE
Expose the CacheObjectProvider.

### DIFF
--- a/lib/flutter_cache_manager.dart
+++ b/lib/flutter_cache_manager.dart
@@ -1,3 +1,4 @@
 export 'src/cache_manager.dart';
 export 'src/file_fetcher.dart';
 export 'src/file_info.dart';
+export 'src/cache_object.dart';

--- a/lib/src/cache_object_db_provider.dart
+++ b/lib/src/cache_object_db_provider.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:sqflite/sqflite.dart';
+
+import 'cache_object.dart';
+/// Sqlite [CacheObjectProvider] implemtation
+class CacheObjectDbProvider extends CacheObjectProvider {
+  Database db;
+  final String path;
+
+  CacheObjectDbProvider(this.path);
+
+  @override
+  Future open() async {
+    db = await openDatabase(path, version: 1,
+        onCreate: (Database db, int version) async {
+      await db.execute('''
+      create table $tableCacheObject ( 
+        $columnId integer primary key, 
+        $columnUrl text, 
+        $columnPath text,
+        $columnETag text,
+        $columnValidTill integer,
+        $columnTouched integer
+        )
+      ''');
+    });
+  }
+
+  @override
+  Future<CacheObject> insert(CacheObject cacheObject) async {
+    cacheObject.id = await db.insert(tableCacheObject, cacheObject.toMap());
+    return cacheObject;
+  }
+
+  @override
+  Future<CacheObject> get(String url) async {
+    List<Map> maps = await db.query(tableCacheObject,
+        columns: null, where: "$columnUrl = ?", whereArgs: [url]);
+    if (maps.length > 0) {
+      return new CacheObject.fromMap(maps.first);
+    }
+    return null;
+  }
+
+  @override
+  Future<dynamic> delete(int id) async {
+    return await db
+        .delete(tableCacheObject, where: "$columnId = ?", whereArgs: [id]);
+  }
+
+  @override
+  Future deleteAll(Iterable<int> ids) async {
+    return await db.delete(tableCacheObject,
+        where: "$columnId IN (" + ids.join(",") + ")");
+  }
+
+  @override
+  Future<int> update(CacheObject cacheObject) async {
+    return await db.update(tableCacheObject, cacheObject.toMap(),
+        where: "$columnId = ?", whereArgs: [cacheObject.id]);
+  }
+
+  @override
+  Future<List<CacheObject>> getAllObjects() async {
+    List<Map> maps = await db.query(tableCacheObject, columns: null);
+    return CacheObject.fromMapList(maps);
+  }
+
+  @override
+  Future<List<CacheObject>> getObjectsOverCapacity(int capacity) async {
+    List<Map> maps = await db.query(tableCacheObject,
+        columns: null,
+        orderBy: "$columnTouched DESC",
+        where: "$columnTouched < ?",
+        whereArgs: [
+          DateTime.now().subtract(new Duration(days: 1)).millisecondsSinceEpoch
+        ],
+        limit: 100,
+        offset: capacity);
+
+    return CacheObject.fromMapList(maps);
+  }
+
+  @override
+  Future<List<CacheObject>> getOldObjects(Duration maxAge) async {
+    List<Map<String, dynamic>> maps = await db.query(
+      tableCacheObject,
+      where: "$columnTouched < ?",
+      columns: null,
+      whereArgs: [DateTime.now().subtract(maxAge).millisecondsSinceEpoch],
+      limit: 100,
+    );
+
+    return CacheObject.fromMapList(maps);
+  }
+
+  @override
+  Future close() async => await db.close();
+}

--- a/test/cache_object_test.dart
+++ b/test/cache_object_test.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_cache_manager/src/cache_object.dart';
+import 'package:flutter_cache_manager/src/cache_object_db_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -31,5 +33,5 @@ Future<CacheObjectProvider> getDbProvider() async {
   try {
     await Directory(databasesPath.path).create(recursive: true);
   } catch (_) {}
-  return new CacheObjectProvider(path);
+  return new CacheObjectDbProvider(path);
 }

--- a/test/cache_store_test.dart
+++ b/test/cache_store_test.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_cache_manager/src/cache_object.dart';
+import 'package:flutter_cache_manager/src/cache_store.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'mock_cache_object_provider.dart';
+void main() {
+  group('Test cache store', () {
+    var basePath = Directory.systemTemp.createTempSync("test");
+    var store = CacheStore(
+      Future.value(basePath.path),
+      getMockProvider(),
+      10,
+      const Duration(seconds: 30),
+    );
+    tearDown(() async {
+      await store.emptyCache();
+    });
+    test("get and put", () async {
+      var testFile = File(p.join(basePath.path, '1.png'));
+      testFile.createSync();
+      await store.putFile(
+        CacheObject("http://test/1.png", relativePath: "1.png"),
+      );
+      expect(await store.getFile("http://test/1.png"),
+          (object) => object.file != null,
+          reason: "should found");
+    });
+    test("get invalid cache", () async {
+      expect(
+        await store.getFile("http://test/2.png"),
+        null,
+        reason: "should not found",
+      );
+      await store.putFile(
+        CacheObject("http://test/2.png"),
+      );
+      expect(await store.getFile("http://test/2.png"), null,
+          reason: "should not found");
+    });
+    test("remove", () async {
+      var testFile = File(p.join(basePath.path, '3.png'));
+      testFile.createSync();
+      await store.putFile(
+        CacheObject("http://test/3.png", relativePath: "3.png"),
+      );
+      var object = await store.retrieveCacheData("http://test/3.png");
+      expect(object, (object) => object.id != null);
+      await store.removeCachedFile(object);
+      expect(await store.retrieveCacheData("http://test/3.png"), null);
+      await Future.delayed(Duration(milliseconds: 200));
+      expect(testFile.existsSync(), false);
+    });
+  });
+}
+
+Future<CacheObjectProvider> getMockProvider() async {
+  return MockCacheObjectProvider();
+}

--- a/test/mock_cache_object_provider.dart
+++ b/test/mock_cache_object_provider.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:flutter_cache_manager/src/cache_object.dart';
+
+class MockCacheObjectProvider extends CacheObjectProvider {
+  final caches = <CacheObject>[];
+  @override
+  Future open() {
+    return Future.value();
+  }
+
+  @override
+  Future close() {
+    caches.clear();
+    return Future.value();
+  }
+
+  @override
+  Future<dynamic> delete(int id) {
+    caches.removeWhere((object) => object.id == id);
+    return Future.value(id);
+  }
+
+  @override
+  Future deleteAll(Iterable<int> ids) {
+    caches.removeWhere((object) => ids.contains(object.id));
+    return Future.value();
+  }
+
+  @override
+  Future<CacheObject> get(String url) {
+    return Future.value(caches.firstWhere(
+      (object) => object.url == url,
+      orElse: () => null,
+    ));
+  }
+
+  @override
+  Future<List<CacheObject>> getAllObjects() {
+    return Future.value(List.unmodifiable(caches));
+  }
+
+  @override
+  Future<List<CacheObject>> getObjectsOverCapacity(int capacity) {
+    // unsuppported in this provider
+    return Future.value([]);
+  }
+
+  @override
+  Future<List<CacheObject>> getOldObjects(Duration maxAge) {
+    // unsuppported in this provider
+    return Future.value([]);
+  }
+
+  @override
+  Future<CacheObject> insert(CacheObject cacheObject) {
+    cacheObject.id = caches.length;
+    caches.add(cacheObject);
+    return Future.value(cacheObject);
+  }
+
+  @override
+  Future<int> update(CacheObject cacheObject) {
+    caches[cacheObject.id] = cacheObject;
+    return Future.value(cacheObject.id);
+  }
+}


### PR DESCRIPTION
For some reason, users may use another library instead of sqlite to implement `CacheObjectProvider`.